### PR TITLE
feat: 增加 OpenAI Codex 账号 OAuth 调用

### DIFF
--- a/GPT_SoVITS/character.py
+++ b/GPT_SoVITS/character.py
@@ -403,10 +403,17 @@ class GetCharacterAttributes:
         l2d_json_paths_dict = d_sakiko_config.l2d_json_paths_dict.value
         loaded_character_names: set[str] = set()
 
-        for char in sorted(os.listdir("../live2d_related")):
+        live2d_related_dir = "../live2d_related"
+        if os.path.isdir(live2d_related_dir):
+            character_entries = sorted(os.listdir(live2d_related_dir))
+        else:
+            logger.warning("角色资源目录不存在，已按空角色列表启动：%s", live2d_related_dir)
+            character_entries = []
+
+        for char in character_entries:
             if char.startswith("."):
                 continue
-            full_path = os.path.join("../live2d_related", char)
+            full_path = os.path.join(live2d_related_dir, char)
             if  os.path.isdir(full_path):    #只遍历文件夹
                 self.character_num+=1
                 character=CharacterAttributes()

--- a/GPT_SoVITS/chat/attachments.py
+++ b/GPT_SoVITS/chat/attachments.py
@@ -102,6 +102,8 @@ def model_supports_image_upload(model: str, *, use_default_deepseek_api: bool = 
         return False
     if model_image_upload_is_blocked(model):
         return False
+    if model.strip().lower().startswith("openai_codex/"):
+        return True
 
     if _litellm_supports_vision(model):
         return True
@@ -111,6 +113,8 @@ def model_supports_image_upload(model: str, *, use_default_deepseek_api: bool = 
 def model_can_force_allow_image_upload(model: str, *, use_default_deepseek_api: bool = False) -> bool:
     """判断当前模型是否允许用户手动加入图片上传白名单。"""
     if use_default_deepseek_api:
+        return False
+    if model.strip().lower().startswith("openai_codex/"):
         return False
     return bool(model.strip()) and not model_image_upload_is_blocked(model)
 

--- a/GPT_SoVITS/chat/model_context_overrides.json
+++ b/GPT_SoVITS/chat/model_context_overrides.json
@@ -45,6 +45,16 @@
       "max_input_tokens": 1000000,
       "max_output_tokens": 384000,
       "source": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash"
+    },
+    {
+      "id": "gpt-5.6-sol",
+      "aliases": [
+        "openai_codex/gpt-5.6-sol",
+        "openai_codex/gpt-5.6-terra",
+        "openai_codex/gpt-5.6-luna"
+      ],
+      "max_input_tokens": 372000,
+      "source": "Cherry Studio provider registry"
     }
   ]
 }

--- a/GPT_SoVITS/chat/model_token_usage.py
+++ b/GPT_SoVITS/chat/model_token_usage.py
@@ -16,7 +16,15 @@ def count_message_tokens(model: str, messages: list[dict[str, object]]) -> int:
     """使用 LiteLLM 计算一组消息在指定模型下消耗的 token 数。"""
     from litellm import token_counter
 
-    token_count = token_counter(model=model.strip(), messages=messages)
+    normalized_model = model.strip()
+    token_model = normalized_model.split("/", 1)[1] if normalized_model.lower().startswith("openai_codex/") else normalized_model
+    try:
+        token_count = token_counter(model=token_model, messages=messages)
+    except Exception:
+        if not normalized_model.lower().startswith("openai_codex/"):
+            raise
+        # LiteLLM 可能尚未收录最新 Codex 账号模型；使用同 tokenizer 家族的模型估算。
+        token_count = token_counter(model="gpt-4o", messages=messages)
     return max(0, int(token_count))
 
 

--- a/GPT_SoVITS/chat/tool_calling.py
+++ b/GPT_SoVITS/chat/tool_calling.py
@@ -261,6 +261,12 @@ class ToolCallingAgentRuntime:
                 ],
             }
 
+            # Codex Responses 在工具调用的下一轮需要回传本轮加密 reasoning item。
+            # 该字段只存在于临时 runtime history，不会进入用户可见消息或持久聊天文本。
+            codex_reasoning_items = parsed.get("codex_reasoning_items")
+            if isinstance(codex_reasoning_items, list) and codex_reasoning_items:
+                assistant_message["_codex_reasoning_items"] = codex_reasoning_items
+
             # DeepSeek V4 在启用思考模式进行工具调用时要求必须返回 reasoning_content
             reasoning_content = parsed.get("reasoning_content")
             if (
@@ -532,15 +538,22 @@ class ToolCallingAgentRuntime:
         content = ""
         reasoning_content = ""
         raw_tool_calls: List[Any] = []
+        codex_reasoning_items: List[Dict[str, Any]] = []
 
         if isinstance(message, dict):
             content = message.get("content") or ""
             reasoning_content = message.get("reasoning_content") or ""
             raw_tool_calls = message.get("tool_calls") or []
+            raw_codex_reasoning = message.get("_codex_reasoning_items") or []
+            if isinstance(raw_codex_reasoning, list):
+                codex_reasoning_items = [dict(item) for item in raw_codex_reasoning if isinstance(item, dict)]
         elif message is not None:
             content = getattr(message, "content", "") or ""
             reasoning_content = getattr(message, "reasoning_content", "") or ""
             raw_tool_calls = getattr(message, "tool_calls", None) or []
+            raw_codex_reasoning = getattr(message, "_codex_reasoning_items", None) or []
+            if isinstance(raw_codex_reasoning, list):
+                codex_reasoning_items = [dict(item) for item in raw_codex_reasoning if isinstance(item, dict)]
 
         parsed_from_content = ToolCallingAgentRuntime._parse_content_json(content)
 
@@ -567,6 +580,7 @@ class ToolCallingAgentRuntime:
             "final_content": parsed_from_content.get("final_content", content),
             "finish_reason": finish_reason,
             "model": model,
+            "codex_reasoning_items": codex_reasoning_items,
         }
 
     @staticmethod

--- a/GPT_SoVITS/dp_local2.py
+++ b/GPT_SoVITS/dp_local2.py
@@ -53,7 +53,11 @@ from chat.rolling_summary import (
 )
 from chat.tool_calling import AgentRunResult, ToolCallingAgentRuntime
 from emotion_enum import EmotionEnum
-from deepseek_prompt_cache_debug import CACHE_DEBUG_PHASE_KEY, log_prompt_cache_usage
+from deepseek_prompt_cache_debug import (
+    CACHE_DEBUG_PHASE_KEY,
+    extract_prompt_cache_usage,
+    log_prompt_cache_usage,
+)
 from llm_provider.modelscope import (
     ModelScopeQuotaExceededError,
     ModelScopeRateLimitKind,
@@ -61,6 +65,15 @@ from llm_provider.modelscope import (
     extract_error_headers,
     parse_quota_headers,
     parse_retry_after_seconds,
+)
+from llm_provider.codex import (
+    OPENAI_CODEX_PROVIDER_ID,
+    CodexAuthenticationError,
+    CodexBadRequestError,
+    CodexConnectionError,
+    CodexPermissionError,
+    CodexRateLimitError,
+    codex_completion,
 )
 
 TOOL_CALL_START_EVENT_PREFIX = "__TOOL_CALL_START__:"
@@ -70,6 +83,34 @@ LOTTERY_UI_EVENT_PREFIX = "__LOTTERY_UI_CMD__:"
 MODELSCOPE_MAX_RATE_LIMIT_RETRIES = 2
 MODELSCOPE_MAX_RETRY_DELAY_SECONDS = 5.0
 logger = get_logger(__name__)
+
+
+def _extract_prompt_cache_usage(response: object) -> Optional[dict[str, object]]:
+    """兼容旧调用点，从 LiteLLM 响应中提取 DeepSeek prompt cache usage。"""
+    return extract_prompt_cache_usage(response)
+
+
+def _log_prompt_cache_usage(response: object, request_kwargs: dict[str, object]) -> None:
+    """记录 DeepSeek prompt cache 命中情况。"""
+    usage = _extract_prompt_cache_usage(response)
+    if usage is None:
+        return
+
+    hit_tokens = int(usage.get("prompt_cache_hit_tokens") or 0)
+    miss_tokens = int(usage.get("prompt_cache_miss_tokens") or 0)
+    total_cache_tokens = hit_tokens + miss_tokens
+    hit_rate = f"{hit_tokens / total_cache_tokens * 100:.2f}%" if total_cache_tokens else "0.00%"
+    model = str(request_kwargs.get("model") or getattr(response, "model", "") or "")
+    logger.info(
+        "deepseek_prompt_cache model=%s hit=%s miss=%s hit_rate=%s prompt=%s completion=%s total=%s",
+        model,
+        hit_tokens,
+        miss_tokens,
+        hit_rate,
+        usage.get("prompt_tokens"),
+        usage.get("completion_tokens"),
+        usage.get("total_tokens"),
+    )
 
 
 class _QueueWriter(Protocol):
@@ -145,7 +186,7 @@ def completion(**kwargs: object) -> object:
     request_kwargs_for_log = dict(kwargs)
     request_kwargs_for_log[CACHE_DEBUG_PHASE_KEY] = cache_debug_phase
     response = litellm.completion(**kwargs)
-    log_prompt_cache_usage(response, request_kwargs_for_log, logger)
+    _log_prompt_cache_usage(response, request_kwargs_for_log)
     return response
 
 
@@ -305,6 +346,8 @@ class DSLocalAndVoiceGen:
         - 第三方 OpenAI 兼容端点：强制走 openai/ 路由（若未带 openai/ 则自动补齐）。
         - litellm 内置 provider：若用户未输入前缀，则尝试补全为 provider/model。
         """
+        if provider == OPENAI_CODEX_PROVIDER_ID:
+            return model if model.startswith(f"{OPENAI_CODEX_PROVIDER_ID}/") else f"{OPENAI_CODEX_PROVIDER_ID}/{model}"
         if provider in THIRD_PARTY_OPENAI_COMPAT_PROVIDER_IDS:
             return ensure_openai_compatible_model(model)
         return DSLocalAndVoiceGen.concat_provider_and_model(provider, model)
@@ -790,6 +833,8 @@ class DSLocalAndVoiceGen:
         """
         按内部 provider id 选择补全请求策略。
         """
+        if provider_id == OPENAI_CODEX_PROVIDER_ID:
+            return codex_completion(**completion_kwargs)
         if provider_id == "modelscope":
             return DSLocalAndVoiceGen._completion_with_modelscope_rate_limit_policy(
                 completion_kwargs
@@ -1043,7 +1088,7 @@ class DSLocalAndVoiceGen:
         else:
             logger.debug("正在使用预定义大模型 API")
             logger.debug("Provider: %s", self.d_sakiko_config.llm_api_provider.value)
-            logger.debug("Model: %s", self.d_sakiko_config.llm_api_model.value[self.d_sakiko_config.llm_api_provider.value])
+            logger.debug("Model: %s", self.d_sakiko_config.llm_api_model.value.get(self.d_sakiko_config.llm_api_provider.value, ""))
             provider = self.d_sakiko_config.llm_api_provider.value
             provider_id = str(provider)
             model_name = self.d_sakiko_config.llm_api_model.value.get(provider, "")
@@ -1460,6 +1505,9 @@ class DSLocalAndVoiceGen:
         使用 LiteLLM 的模型参数表判断当前配置是否应尝试 JSON Mode。
         """
         import litellm
+
+        if self.d_sakiko_config.llm_api_provider.value == OPENAI_CODEX_PROVIDER_ID:
+            return False
 
         get_supported_params = getattr(litellm, "get_supported_openai_params", None)
         if not callable(get_supported_params):
@@ -2310,6 +2358,33 @@ class DSLocalAndVoiceGen:
                         )
                     )
 
+            except (
+                CodexAuthenticationError,
+                CodexRateLimitError,
+                CodexPermissionError,
+                CodexConnectionError,
+                CodexBadRequestError,
+            ) as e:
+                if isinstance(e, CodexAuthenticationError):
+                    user_message = "OpenAI Codex 登录已失效，请在配置中重新登录。"
+                elif isinstance(e, CodexRateLimitError):
+                    user_message = "OpenAI Codex 请求过于频繁或账号额度已用完，请稍后再试。"
+                elif isinstance(e, CodexPermissionError):
+                    user_message = "当前 OpenAI Codex 账号无权使用所选模型，请切换模型。"
+                elif isinstance(e, CodexConnectionError):
+                    user_message = "与 OpenAI Codex 建立连接失败，请检查网络。"
+                else:
+                    user_message = f"OpenAI Codex 请求错误：{e}"
+                self._report_model_exception(
+                    dp2qt_queue,
+                    active_chat_id,
+                    turn_id,
+                    is_text_generating_queue,
+                    user_message,
+                    e,
+                )
+                self._emit_turn_complete(dp2qt_queue, active_chat_id, turn_id, "error")
+                continue
             except litellm.exceptions.Timeout as e:
                 self._report_model_exception(
                     dp2qt_queue,

--- a/GPT_SoVITS/dp_local_multi_char.py
+++ b/GPT_SoVITS/dp_local_multi_char.py
@@ -3,6 +3,15 @@ import time,os
 from qconfig import d_sakiko_config, THIRD_PARTY_OPENAI_COMPAT_PROVIDER_IDS
 from llm_model_utils import ensure_openai_compatible_model
 from character import CharacterAttributes
+from llm_provider.codex import (
+	OPENAI_CODEX_PROVIDER_ID,
+	CodexAuthenticationError,
+	CodexBadRequestError,
+	CodexConnectionError,
+	CodexPermissionError,
+	CodexRateLimitError,
+	codex_completion,
+)
 
 
 class DSLocalAndVoiceGen:
@@ -68,6 +77,8 @@ class DSLocalAndVoiceGen:
 		- 第三方 OpenAI 兼容端点：强制走 openai/ 路由（若未带 openai/ 则自动补齐）。
 		- litellm 内置 provider：若用户未输入前缀，则尝试补全为 provider/model。
 		"""
+		if provider == OPENAI_CODEX_PROVIDER_ID:
+			return model if model.startswith(f"{OPENAI_CODEX_PROVIDER_ID}/") else f"{OPENAI_CODEX_PROVIDER_ID}/{model}"
 		if provider in THIRD_PARTY_OPENAI_COMPAT_PROVIDER_IDS:
 			return ensure_openai_compatible_model(model)
 		return DSLocalAndVoiceGen.concat_provider_and_model(provider, model)
@@ -82,6 +93,21 @@ class DSLocalAndVoiceGen:
 		text_queue.put('error')
 		# 源代码如此，我也不知道为啥要休息一会
 		time.sleep(2)
+
+	@staticmethod
+	def _extract_response_content(response: object) -> str:
+		"""兼容 LiteLLM ModelResponse 与 Codex 归一化字典。"""
+		if isinstance(response, dict):
+			choices = response.get("choices") or []
+			if choices and isinstance(choices[0], dict):
+				message = choices[0].get("message") or {}
+				if isinstance(message, dict):
+					return str(message.get("content") or "")
+		choices = getattr(response, "choices", None) or []
+		if choices:
+			message = getattr(choices[0], "message", None)
+			return str(getattr(message, "content", "") or "")
+		return ""
 
 	def text_generator(self,
 					   text_queue,
@@ -178,7 +204,14 @@ class DSLocalAndVoiceGen:
 					api_key = d_sakiko_config.llm_api_key.value.get(provider, "")
 					base_url = d_sakiko_config.llm_api_base_url.value.get(provider)
 
-					if base_url:
+					if provider == OPENAI_CODEX_PROVIDER_ID:
+						response = codex_completion(
+							model=self.normalize_model_for_provider(provider, model),
+							messages=user_this_turn_msg,
+							stream=False,
+							timeout=100,
+						)
+					elif base_url:
 						response = completion(
 							model=self.normalize_model_for_provider(provider, model),
 							messages=user_this_turn_msg,
@@ -201,6 +234,21 @@ class DSLocalAndVoiceGen:
 							top_p = top_p,
 							drop_params = True
 						)
+			except CodexAuthenticationError:
+				self.report_message_to_main_ui(message_queue, text_queue, "OpenAI Codex 登录已失效，请重新登录。")
+				continue
+			except CodexRateLimitError:
+				self.report_message_to_main_ui(message_queue, text_queue, "OpenAI Codex 请求过于频繁或账号额度已用完。")
+				continue
+			except CodexPermissionError:
+				self.report_message_to_main_ui(message_queue, text_queue, "当前 OpenAI Codex 账号无权使用所选模型。")
+				continue
+			except CodexConnectionError:
+				self.report_message_to_main_ui(message_queue, text_queue, "与 OpenAI Codex 建立连接失败，请检查网络。")
+				continue
+			except CodexBadRequestError as e:
+				self.report_message_to_main_ui(message_queue, text_queue, f"OpenAI Codex 请求错误：{e}")
+				continue
 			except litellm.exceptions.Timeout:
 				self.report_message_to_main_ui(
 					message_queue,
@@ -264,7 +312,8 @@ class DSLocalAndVoiceGen:
 
 				continue
 
-			if not isinstance(response, ModelResponse) or response.choices[0].message.content is None:
+			response_content = self._extract_response_content(response)
+			if not response_content:
 				self.report_message_to_main_ui(
 					message_queue,
 					text_queue,
@@ -273,7 +322,7 @@ class DSLocalAndVoiceGen:
 				continue
 
 			# 去掉多余的字符，使用正则表达式
-			response_json=response.choices[0].message.content.strip()
+			response_json=response_content.strip()
 			text_queue.put(response_json)
 
 if __name__ == "__main__":

--- a/GPT_SoVITS/llm_provider/codex.py
+++ b/GPT_SoVITS/llm_provider/codex.py
@@ -1,0 +1,690 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+import threading
+import time
+import urllib.parse
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Callable, Mapping, Sequence
+
+import requests
+
+
+OPENAI_CODEX_PROVIDER_ID = "openai_codex"
+CODEX_API_URL = "https://chatgpt.com/backend-api/codex/responses"
+CODEX_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
+CODEX_TOKEN_URL = "https://auth.openai.com/oauth/token"
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_CALLBACK_PORTS = (1455, 1457)
+CODEX_MODELS = (
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
+)
+DEFAULT_CODEX_MODEL = CODEX_MODELS[0]
+TOKEN_REFRESH_MARGIN_SECONDS = 300
+
+
+class CodexError(RuntimeError):
+    """OpenAI Codex provider 的基础异常。"""
+
+
+class CodexAuthenticationError(CodexError):
+    """登录缺失、令牌过期或刷新失败。"""
+
+
+class CodexRateLimitError(CodexError):
+    """Codex 账号额度或速率受限。"""
+
+
+class CodexPermissionError(CodexError):
+    """当前账号无权访问请求的模型。"""
+
+
+class CodexBadRequestError(CodexError):
+    """Codex 拒绝了请求内容。"""
+
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class CodexConnectionError(CodexError):
+    """无法连接 OAuth 或 Codex 服务。"""
+
+
+def _base64url_no_padding(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """生成 OAuth PKCE verifier/challenge。"""
+    verifier = _base64url_no_padding(secrets.token_bytes(64))
+    challenge = _base64url_no_padding(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+def build_authorization_url(redirect_uri: str, state: str, code_challenge: str) -> str:
+    """构造与 Codex CLI 登录兼容的授权地址。"""
+    query = urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "client_id": CODEX_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "scope": "openid profile email offline_access",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "id_token_add_organizations": "true",
+            "codex_cli_simplified_flow": "true",
+            "state": state,
+            "originator": "d_sakiko",
+        }
+    )
+    return f"{CODEX_AUTHORIZE_URL}?{query}"
+
+
+def _decode_jwt_payload(token: object) -> dict[str, object]:
+    if not isinstance(token, str) or token.count(".") < 2:
+        return {}
+    try:
+        encoded = token.split(".", 2)[1]
+        encoded += "=" * (-len(encoded) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(encoded.encode("ascii")))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _extract_account_metadata(token_payload: Mapping[str, object]) -> dict[str, str]:
+    auth_claim = token_payload.get("https://api.openai.com/auth")
+    auth = auth_claim if isinstance(auth_claim, Mapping) else {}
+
+    def first_string(*values: object) -> str:
+        for value in values:
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    return {
+        "account_id": first_string(
+            auth.get("chatgpt_account_id"),
+            token_payload.get("chatgpt_account_id"),
+            token_payload.get("account_id"),
+        ),
+        "email": first_string(token_payload.get("email"), auth.get("email")),
+        "plan_type": first_string(
+            auth.get("chatgpt_plan_type"),
+            token_payload.get("chatgpt_plan_type"),
+            token_payload.get("plan_type"),
+        ),
+    }
+
+
+def normalize_token_response(
+    response_data: Mapping[str, object],
+    *,
+    previous_refresh_token: str = "",
+    now: float | None = None,
+) -> dict[str, object]:
+    """把 OAuth token 响应转换为可持久化的稳定结构。"""
+    access_token = str(response_data.get("access_token") or "").strip()
+    if not access_token:
+        raise CodexAuthenticationError("OAuth 响应缺少 access_token。")
+    refresh_token = str(response_data.get("refresh_token") or previous_refresh_token or "").strip()
+    id_token = str(response_data.get("id_token") or "").strip()
+    try:
+        expires_in = max(1, int(response_data.get("expires_in") or 3600))
+    except (TypeError, ValueError):
+        expires_in = 3600
+
+    access_claims = _decode_jwt_payload(access_token)
+    id_claims = _decode_jwt_payload(id_token)
+    metadata = _extract_account_metadata({**id_claims, **access_claims})
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "id_token": id_token,
+        "expires_at": float(time.time() if now is None else now) + expires_in,
+        **metadata,
+    }
+
+
+def load_codex_oauth_bundle() -> dict[str, object]:
+    """从统一配置中读取最新 Codex OAuth 令牌。"""
+    from qconfig import d_sakiko_config
+
+    snapshot = d_sakiko_config.snapshot()
+    raw = getattr(snapshot, "codex_oauth").value
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
+def save_codex_oauth_bundle(bundle: Mapping[str, object]) -> None:
+    """原子写入 Codex OAuth 令牌。"""
+    from qconfig import d_sakiko_config
+
+    d_sakiko_config.set(d_sakiko_config.codex_oauth, dict(bundle))
+
+
+def clear_codex_oauth_bundle() -> None:
+    save_codex_oauth_bundle({})
+
+
+def codex_account_summary() -> dict[str, str]:
+    bundle = load_codex_oauth_bundle()
+    return {
+        "account_id": str(bundle.get("account_id") or ""),
+        "email": str(bundle.get("email") or ""),
+        "plan_type": str(bundle.get("plan_type") or ""),
+    }
+
+
+class _OAuthCallbackServer:
+    def __init__(self, state: str) -> None:
+        self.state = state
+        self.result: dict[str, str] = {}
+        self.server: HTTPServer | None = None
+        last_error: OSError | None = None
+
+        callback_owner = self
+
+        class CallbackHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+                parsed = urllib.parse.urlparse(self.path)
+                if parsed.path != "/auth/callback":
+                    self.send_error(404)
+                    return
+                params = urllib.parse.parse_qs(parsed.query)
+                received_state = (params.get("state") or [""])[0]
+                if received_state != callback_owner.state:
+                    callback_owner.result = {"error": "OAuth state 校验失败。"}
+                    self._finish(400, "登录失败：state 校验失败，可以关闭此页面。")
+                    return
+                error = (params.get("error_description") or params.get("error") or [""])[0]
+                code = (params.get("code") or [""])[0]
+                if error:
+                    callback_owner.result = {"error": error}
+                    self._finish(400, "登录被取消或拒绝，可以关闭此页面。")
+                    return
+                if not code:
+                    callback_owner.result = {"error": "OAuth 回调缺少授权码。"}
+                    self._finish(400, "登录失败：缺少授权码，可以关闭此页面。")
+                    return
+                callback_owner.result = {"code": code}
+                self._finish(200, "OpenAI Codex 登录成功，可以关闭此页面并返回 D_sakiko。")
+
+            def _finish(self, status: int, message: str) -> None:
+                body = (
+                    "<!doctype html><meta charset='utf-8'>"
+                    "<title>D_sakiko Codex</title>"
+                    f"<body style='font-family:sans-serif;padding:40px'><h2>{message}</h2></body>"
+                ).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+        for port in CODEX_CALLBACK_PORTS:
+            try:
+                self.server = HTTPServer(("127.0.0.1", port), CallbackHandler)
+                self.server.timeout = 0.25
+                self.port = port
+                break
+            except OSError as exc:
+                last_error = exc
+        else:
+            raise CodexConnectionError(
+                f"OAuth 回调端口 {CODEX_CALLBACK_PORTS} 均不可用。"
+            ) from last_error
+
+    @property
+    def redirect_uri(self) -> str:
+        return f"http://localhost:{self.port}/auth/callback"
+
+    def wait(self, cancel_event: threading.Event, timeout: float) -> str:
+        assert self.server is not None
+        deadline = time.monotonic() + timeout
+        try:
+            while not self.result and not cancel_event.is_set() and time.monotonic() < deadline:
+                self.server.handle_request()
+        finally:
+            self.server.server_close()
+        if cancel_event.is_set():
+            raise CodexAuthenticationError("登录已取消。")
+        if not self.result:
+            raise CodexAuthenticationError("等待 OAuth 登录超时。")
+        if self.result.get("error"):
+            raise CodexAuthenticationError(self.result["error"])
+        return self.result["code"]
+
+    def close(self) -> None:
+        """关闭尚未进入等待循环的回调服务器。"""
+        if self.server is not None:
+            self.server.server_close()
+
+
+class CodexOAuthClient:
+    """负责登录、刷新和提供当前可用的 Codex access token。"""
+
+    _refresh_lock = threading.Lock()
+
+    def __init__(self, session: requests.Session | None = None) -> None:
+        self.session = session or requests.Session()
+
+    def sign_in(
+        self,
+        *,
+        cancel_event: threading.Event | None = None,
+        timeout: float = 300,
+        open_browser: Callable[[str], object] = webbrowser.open,
+    ) -> dict[str, object]:
+        cancel_event = cancel_event or threading.Event()
+        verifier, challenge = generate_pkce_pair()
+        state = _base64url_no_padding(secrets.token_bytes(32))
+        callback = _OAuthCallbackServer(state)
+        auth_url = build_authorization_url(callback.redirect_uri, state, challenge)
+        browser_opened = open_browser(auth_url)
+        if browser_opened is False:
+            callback.close()
+            raise CodexConnectionError("未能打开 OAuth 登录页面。")
+        code = callback.wait(cancel_event, timeout)
+        token_data = self._post_token(
+            {
+                "grant_type": "authorization_code",
+                "client_id": CODEX_CLIENT_ID,
+                "code": code,
+                "redirect_uri": callback.redirect_uri,
+                "code_verifier": verifier,
+            }
+        )
+        bundle = normalize_token_response(token_data)
+        save_codex_oauth_bundle(bundle)
+        return bundle
+
+    def _post_token(self, payload: Mapping[str, object]) -> Mapping[str, object]:
+        try:
+            response = self.session.post(CODEX_TOKEN_URL, data=dict(payload), timeout=30)
+        except requests.RequestException as exc:
+            raise CodexConnectionError("连接 OpenAI OAuth 服务失败。") from exc
+        if response.status_code >= 400:
+            raise CodexAuthenticationError(_response_error_text(response, "OAuth 令牌请求失败。"))
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise CodexAuthenticationError("OAuth 服务返回了无效 JSON。") from exc
+        if not isinstance(data, Mapping):
+            raise CodexAuthenticationError("OAuth 服务返回结构无效。")
+        return data
+
+    def get_access_bundle(
+        self,
+        *,
+        force_refresh: bool = False,
+        stale_access_token: str | None = None,
+    ) -> dict[str, object]:
+        bundle = load_codex_oauth_bundle()
+        if not bundle.get("access_token"):
+            raise CodexAuthenticationError("尚未登录 OpenAI Codex。")
+        expires_at = _as_float(bundle.get("expires_at"))
+        if not force_refresh and expires_at > time.time() + TOKEN_REFRESH_MARGIN_SECONDS:
+            return bundle
+        access_token_before_lock = str(stale_access_token or bundle.get("access_token") or "")
+
+        with self._refresh_lock:
+            latest = load_codex_oauth_bundle()
+            latest_expires_at = _as_float(latest.get("expires_at"))
+            if not force_refresh and latest_expires_at > time.time() + TOKEN_REFRESH_MARGIN_SECONDS:
+                return latest
+            # 多个请求同时收到 401 时，第一个请求刷新后，后续请求直接复用新令牌，
+            # 避免在全局锁内重复消耗 refresh token。
+            if (
+                force_refresh
+                and str(latest.get("access_token") or "") != access_token_before_lock
+                and latest_expires_at > time.time() + TOKEN_REFRESH_MARGIN_SECONDS
+            ):
+                return latest
+            refresh_token = str(latest.get("refresh_token") or "")
+            if not refresh_token:
+                raise CodexAuthenticationError("Codex 登录已过期，请重新登录。")
+            token_data = self._post_token(
+                {
+                    "grant_type": "refresh_token",
+                    "client_id": CODEX_CLIENT_ID,
+                    "refresh_token": refresh_token,
+                }
+            )
+            refreshed = normalize_token_response(
+                token_data,
+                previous_refresh_token=refresh_token,
+            )
+            for key in ("account_id", "email", "plan_type", "id_token"):
+                if not refreshed.get(key) and latest.get(key):
+                    refreshed[key] = latest[key]
+            save_codex_oauth_bundle(refreshed)
+            return refreshed
+
+
+def _as_float(value: object) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _response_error_text(response: requests.Response, fallback: str) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+        if isinstance(error, str) and error:
+            return error
+        message = payload.get("message")
+        if isinstance(message, str) and message:
+            return message
+    text = str(getattr(response, "text", "") or "").strip()
+    return text[:500] if text else fallback
+
+
+def _message_content_to_responses(content: object) -> object:
+    if not isinstance(content, list):
+        return str(content or "")
+    parts: list[dict[str, object]] = []
+    for part in content:
+        if not isinstance(part, Mapping):
+            continue
+        part_type = part.get("type")
+        if part_type == "text":
+            parts.append({"type": "input_text", "text": str(part.get("text") or "")})
+        elif part_type == "image_url":
+            image = part.get("image_url")
+            image_url = image.get("url") if isinstance(image, Mapping) else image
+            if isinstance(image_url, str) and image_url:
+                converted: dict[str, object] = {"type": "input_image", "image_url": image_url}
+                if isinstance(image, Mapping) and image.get("detail"):
+                    converted["detail"] = image["detail"]
+                parts.append(converted)
+    return parts
+
+
+def messages_to_responses_input(messages: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    """把 Chat Completions 历史转换成 Responses input items。"""
+    items: list[dict[str, object]] = []
+    for message in messages:
+        role = str(message.get("role") or "user")
+        if role == "tool":
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": str(message.get("tool_call_id") or ""),
+                    "output": str(message.get("content") or ""),
+                }
+            )
+            continue
+
+        hidden_reasoning = message.get("_codex_reasoning_items")
+        if isinstance(hidden_reasoning, list):
+            items.extend(dict(item) for item in hidden_reasoning if isinstance(item, Mapping))
+
+        content = message.get("content")
+        if content not in (None, "", []):
+            normalized_role = "developer" if role == "system" else role
+            items.append(
+                {
+                    "role": normalized_role,
+                    "content": _message_content_to_responses(content),
+                }
+            )
+
+        tool_calls = message.get("tool_calls")
+        if role == "assistant" and isinstance(tool_calls, list):
+            for call in tool_calls:
+                if not isinstance(call, Mapping):
+                    continue
+                function = call.get("function")
+                if not isinstance(function, Mapping):
+                    continue
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": str(call.get("id") or ""),
+                        "name": str(function.get("name") or ""),
+                        "arguments": str(function.get("arguments") or "{}"),
+                    }
+                )
+    return items
+
+
+def tools_to_responses_tools(tools: Sequence[Mapping[str, object]] | None) -> list[dict[str, object]]:
+    converted: list[dict[str, object]] = []
+    for tool in tools or ():
+        function = tool.get("function") if isinstance(tool, Mapping) else None
+        if not isinstance(function, Mapping):
+            continue
+        item: dict[str, object] = {
+            "type": "function",
+            "name": str(function.get("name") or ""),
+            "parameters": function.get("parameters") or {"type": "object", "properties": {}},
+        }
+        if function.get("description"):
+            item["description"] = str(function["description"])
+        if "strict" in function:
+            item["strict"] = bool(function["strict"])
+        converted.append(item)
+    return converted
+
+
+def build_codex_request_payload(
+    *,
+    model: str,
+    messages: Sequence[Mapping[str, object]],
+    tools: Sequence[Mapping[str, object]] | None = None,
+    tool_choice: object = "auto",
+    **kwargs: object,
+) -> dict[str, object]:
+    """构造 ChatGPT Codex Responses 请求体并过滤不受支持的参数。"""
+    model_id = model.split("/", 1)[1] if model.startswith(f"{OPENAI_CODEX_PROVIDER_ID}/") else model
+    system_instructions: list[str] = []
+    input_messages: list[Mapping[str, object]] = []
+    for message in messages:
+        if str(message.get("role") or "") == "system":
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                system_instructions.append(content)
+            continue
+        input_messages.append(message)
+
+    payload: dict[str, object] = {
+        "model": model_id,
+        "input": messages_to_responses_input(input_messages),
+        "store": False,
+        "stream": False,
+        "include": ["reasoning.encrypted_content"],
+    }
+    if system_instructions:
+        payload["instructions"] = "\n\n".join(system_instructions)
+    response_tools = tools_to_responses_tools(tools)
+    if response_tools:
+        payload["tools"] = response_tools
+        if isinstance(tool_choice, str) and tool_choice in {"auto", "none", "required"}:
+            payload["tool_choice"] = tool_choice
+        elif isinstance(tool_choice, Mapping):
+            function = tool_choice.get("function")
+            if isinstance(function, Mapping) and function.get("name"):
+                payload["tool_choice"] = {"type": "function", "name": function["name"]}
+
+    thinking = kwargs.get("thinking")
+    effort = kwargs.get("reasoning_effort")
+    reasoning: dict[str, object] = {}
+    if isinstance(thinking, Mapping) and thinking.get("type") == "disabled":
+        reasoning["effort"] = "none"
+    elif effort not in (None, "", "default"):
+        reasoning["effort"] = effort
+    if not (isinstance(thinking, Mapping) and thinking.get("type") == "disabled"):
+        reasoning["summary"] = "auto"
+    if reasoning:
+        payload["reasoning"] = reasoning
+    return payload
+
+
+def responses_to_chat_completion(payload: Mapping[str, object]) -> dict[str, object]:
+    """把 Responses 返回值转换为现有工具链使用的 Chat Completions 结构。"""
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, object]] = []
+    reasoning_items: list[dict[str, object]] = []
+    output = payload.get("output")
+    if isinstance(output, list):
+        for item in output:
+            if not isinstance(item, Mapping):
+                continue
+            item_type = item.get("type")
+            if item_type == "reasoning" and item.get("encrypted_content"):
+                reasoning_items.append(dict(item))
+            elif item_type == "function_call":
+                tool_calls.append(
+                    {
+                        "id": str(item.get("call_id") or item.get("id") or ""),
+                        "type": "function",
+                        "function": {
+                            "name": str(item.get("name") or ""),
+                            "arguments": str(item.get("arguments") or "{}"),
+                        },
+                    }
+                )
+            elif item_type == "message":
+                content = item.get("content")
+                if isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, Mapping) and part.get("type") == "output_text":
+                            text_parts.append(str(part.get("text") or ""))
+
+    if not text_parts and isinstance(payload.get("output_text"), str):
+        text_parts.append(str(payload["output_text"]))
+    message: dict[str, object] = {
+        "role": "assistant",
+        "content": "".join(text_parts),
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    if reasoning_items:
+        message["_codex_reasoning_items"] = reasoning_items
+
+    raw_usage = payload.get("usage")
+    usage: dict[str, object] = {}
+    if isinstance(raw_usage, Mapping):
+        input_tokens = int(raw_usage.get("input_tokens") or 0)
+        output_tokens = int(raw_usage.get("output_tokens") or 0)
+        usage = {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": output_tokens,
+            "total_tokens": int(raw_usage.get("total_tokens") or input_tokens + output_tokens),
+        }
+        details = raw_usage.get("input_tokens_details")
+        if isinstance(details, Mapping) and details.get("cached_tokens") is not None:
+            usage["prompt_tokens_details"] = {"cached_tokens": details.get("cached_tokens")}
+
+    return {
+        "id": str(payload.get("id") or ""),
+        "object": "chat.completion",
+        "model": str(payload.get("model") or ""),
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+            }
+        ],
+        "usage": usage,
+    }
+
+
+def _raise_for_codex_response(response: requests.Response) -> None:
+    if response.status_code < 400:
+        return
+    message = _response_error_text(response, f"Codex 请求失败（HTTP {response.status_code}）。")
+    if response.status_code == 401:
+        raise CodexAuthenticationError(message)
+    if response.status_code == 403:
+        raise CodexPermissionError(message)
+    if response.status_code == 429:
+        raise CodexRateLimitError(message)
+    if response.status_code == 408 or response.status_code >= 500:
+        raise CodexConnectionError(message)
+    raise CodexBadRequestError(message, status_code=response.status_code)
+
+
+def codex_completion(
+    *,
+    model: str,
+    messages: Sequence[Mapping[str, object]],
+    tools: Sequence[Mapping[str, object]] | None = None,
+    tool_choice: object = "auto",
+    oauth_client: CodexOAuthClient | None = None,
+    **kwargs: object,
+) -> dict[str, object]:
+    """用 Codex OAuth 调用 Responses，并返回 Chat Completions 风格字典。"""
+    client = oauth_client or CodexOAuthClient()
+    request_payload = build_codex_request_payload(
+        model=model,
+        messages=messages,
+        tools=tools,
+        tool_choice=tool_choice,
+        **kwargs,
+    )
+    timeout = float(kwargs.get("timeout") or 30)
+
+    def send(bundle: Mapping[str, object]) -> requests.Response:
+        headers = {
+            "Authorization": f"Bearer {bundle.get('access_token', '')}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "OpenAI-Beta": "responses=experimental",
+            "originator": "d_sakiko",
+        }
+        account_id = str(bundle.get("account_id") or "")
+        if account_id:
+            headers["chatgpt-account-id"] = account_id
+        try:
+            return client.session.post(
+                CODEX_API_URL,
+                headers=headers,
+                json=request_payload,
+                timeout=timeout,
+            )
+        except requests.Timeout as exc:
+            raise CodexConnectionError("Codex 请求超时。") from exc
+        except requests.RequestException as exc:
+            raise CodexConnectionError("连接 OpenAI Codex 服务失败。") from exc
+
+    bundle = client.get_access_bundle()
+    response = send(bundle)
+    if response.status_code == 401:
+        bundle = client.get_access_bundle(
+            force_refresh=True,
+            stale_access_token=str(bundle.get("access_token") or ""),
+        )
+        response = send(bundle)
+    _raise_for_codex_response(response)
+    try:
+        response_payload = response.json()
+    except ValueError as exc:
+        raise CodexBadRequestError("Codex 返回了无效 JSON。", status_code=response.status_code) from exc
+    if not isinstance(response_payload, Mapping):
+        raise CodexBadRequestError("Codex 返回结构无效。", status_code=response.status_code)
+    return responses_to_chat_completion(response_payload)

--- a/GPT_SoVITS/llm_provider/codex.py
+++ b/GPT_SoVITS/llm_provider/codex.py
@@ -514,7 +514,9 @@ def build_codex_request_payload(
         "model": model_id,
         "input": messages_to_responses_input(input_messages),
         "store": False,
-        "stream": False,
+        # ChatGPT 的 Codex backend 是 stream-only 接口。项目上层仍然使用
+        # 非流式调用；这里在 transport 层读取完整 SSE 后再返回统一结果。
+        "stream": True,
         "include": ["reasoning.encrypted_content"],
     }
     if system_instructions:
@@ -614,6 +616,180 @@ def responses_to_chat_completion(payload: Mapping[str, object]) -> dict[str, obj
     }
 
 
+def _decode_sse_line(raw_line: object) -> str:
+    if isinstance(raw_line, bytes):
+        return raw_line.decode("utf-8", errors="replace")
+    return str(raw_line or "")
+
+
+def _iter_sse_json_events(response: requests.Response):
+    """逐个解析 Responses SSE 事件，只向调用者暴露 JSON data。"""
+    data_lines: list[str] = []
+
+    def flush():
+        if not data_lines:
+            return None
+        raw_data = "\n".join(data_lines).strip()
+        data_lines.clear()
+        if not raw_data or raw_data == "[DONE]":
+            return None
+        try:
+            event = json.loads(raw_data)
+        except ValueError as exc:
+            raise CodexBadRequestError("Codex 返回了无效的 SSE JSON。") from exc
+        if not isinstance(event, Mapping):
+            raise CodexBadRequestError("Codex 返回了无效的 SSE 事件。")
+        return event
+
+    try:
+        lines = response.iter_lines(decode_unicode=False)
+    except (AttributeError, TypeError) as exc:
+        raise CodexBadRequestError("Codex 返回的 SSE 响应不可读取。") from exc
+
+    try:
+        for raw_line in lines:
+            line = _decode_sse_line(raw_line).rstrip("\r")
+            if not line:
+                event = flush()
+                if event is not None:
+                    yield event
+                continue
+            if line.startswith(":"):
+                continue
+            if line.startswith("data:"):
+                data_lines.append(line[5:].lstrip())
+    except requests.Timeout as exc:
+        raise CodexConnectionError("Codex SSE 读取超时。") from exc
+    except requests.RequestException as exc:
+        raise CodexConnectionError("Codex SSE 连接中断。") from exc
+
+    event = flush()
+    if event is not None:
+        yield event
+
+
+def _event_output_index(event: Mapping[str, object], fallback: int) -> int:
+    try:
+        return int(event.get("output_index", fallback))
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _ensure_message_text_item(
+    output_items: dict[int, dict[str, object]],
+    output_index: int,
+    content_index: int,
+) -> dict[str, object]:
+    item = output_items.setdefault(
+        output_index,
+        {"type": "message", "role": "assistant", "content": []},
+    )
+    if item.get("type") != "message":
+        item = {"type": "message", "role": "assistant", "content": []}
+        output_items[output_index] = item
+    content = item.get("content")
+    if not isinstance(content, list):
+        content = []
+        item["content"] = content
+    while len(content) <= content_index:
+        content.append({"type": "output_text", "text": "", "annotations": []})
+    part = content[content_index]
+    if not isinstance(part, dict) or part.get("type") != "output_text":
+        part = {"type": "output_text", "text": "", "annotations": []}
+        content[content_index] = part
+    return part
+
+
+def _sse_failure_message(event: Mapping[str, object]) -> str:
+    response = event.get("response")
+    error = response.get("error") if isinstance(response, Mapping) else event.get("error")
+    if isinstance(error, Mapping):
+        message = error.get("message")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+    if isinstance(error, str) and error.strip():
+        return error.strip()
+    return "Codex 流式响应失败。"
+
+
+def collect_codex_sse_response(response: requests.Response) -> dict[str, object]:
+    """把 Codex stream-only SSE 在 transport 层聚合为完整 Responses 对象。"""
+    response_meta: dict[str, object] = {}
+    completed_response: dict[str, object] | None = None
+    output_items: dict[int, dict[str, object]] = {}
+    saw_event = False
+    saw_completed = False
+
+    for event in _iter_sse_json_events(response):
+        saw_event = True
+        event_type = str(event.get("type") or "")
+        event_response = event.get("response")
+        if isinstance(event_response, Mapping):
+            for key, value in event_response.items():
+                if key != "output" and value is not None:
+                    response_meta[key] = value
+
+        if event_type in {"response.output_item.added", "response.output_item.done"}:
+            item = event.get("item")
+            if isinstance(item, Mapping):
+                index = _event_output_index(event, len(output_items))
+                # done 事件含有最终文本、函数参数和 encrypted reasoning，直接覆盖快照。
+                output_items[index] = dict(item)
+        elif event_type in {"response.output_text.delta", "response.output_text.done"}:
+            output_index = _event_output_index(event, 0)
+            try:
+                content_index = int(event.get("content_index", 0))
+            except (TypeError, ValueError):
+                content_index = 0
+            part = _ensure_message_text_item(output_items, output_index, content_index)
+            if event_type.endswith(".delta"):
+                part["text"] = str(part.get("text") or "") + str(event.get("delta") or "")
+            elif isinstance(event.get("text"), str):
+                part["text"] = event["text"]
+        elif event_type in {
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+        }:
+            output_index = _event_output_index(event, len(output_items))
+            item = output_items.setdefault(
+                output_index,
+                {
+                    "type": "function_call",
+                    "call_id": str(event.get("call_id") or event.get("item_id") or ""),
+                    "name": str(event.get("name") or ""),
+                    "arguments": "",
+                },
+            )
+            if event_type.endswith(".delta"):
+                item["arguments"] = str(item.get("arguments") or "") + str(event.get("delta") or "")
+            elif isinstance(event.get("arguments"), str):
+                item["arguments"] = event["arguments"]
+        elif event_type == "response.failed":
+            raise CodexBadRequestError(_sse_failure_message(event))
+        elif event_type == "response.incomplete":
+            raise CodexBadRequestError("Codex 响应未完整结束。")
+
+        if event_type == "response.completed":
+            saw_completed = True
+            if isinstance(event_response, Mapping):
+                completed_response = dict(event_response)
+
+    if not saw_event:
+        raise CodexBadRequestError("Codex 返回了空的 SSE 响应。")
+    if not saw_completed:
+        raise CodexConnectionError("Codex SSE 在 response.completed 前中断。")
+
+    final_response = dict(response_meta)
+    if completed_response is not None:
+        final_response.update({key: value for key, value in completed_response.items() if value is not None})
+    completed_output = final_response.get("output")
+    # Codex backend 有时在 response.completed 中返回 output:null；此时以此前的
+    # output_item.done 快照为准，避免丢失文本、工具调用和 encrypted reasoning。
+    if not isinstance(completed_output, list) or not completed_output:
+        final_response["output"] = [output_items[index] for index in sorted(output_items)]
+    return final_response
+
+
 def _raise_for_codex_response(response: requests.Response) -> None:
     if response.status_code < 400:
         return
@@ -653,7 +829,7 @@ def codex_completion(
         headers = {
             "Authorization": f"Bearer {bundle.get('access_token', '')}",
             "Content-Type": "application/json",
-            "Accept": "application/json",
+            "Accept": "text/event-stream",
             "OpenAI-Beta": "responses=experimental",
             "originator": "d_sakiko",
         }
@@ -666,6 +842,7 @@ def codex_completion(
                 headers=headers,
                 json=request_payload,
                 timeout=timeout,
+                stream=True,
             )
         except requests.Timeout as exc:
             raise CodexConnectionError("Codex 请求超时。") from exc
@@ -681,6 +858,12 @@ def codex_completion(
         )
         response = send(bundle)
     _raise_for_codex_response(response)
+    content_type = str(getattr(response, "headers", {}).get("Content-Type", "") or "").lower()
+    # chatgpt.com 当前可能省略 Content-Type，只保留 chunked SSE；请求本身已经
+    # 明确 stream:true，因此无 Content-Type 时也按事件流读取。明确声明 JSON 的
+    # 兼容 relay 仍走下方 JSON 分支。
+    if "text/event-stream" in content_type or not content_type:
+        return responses_to_chat_completion(collect_codex_sse_response(response))
     try:
         response_payload = response.json()
     except ValueError as exc:

--- a/GPT_SoVITS/multi_char_main.py
+++ b/GPT_SoVITS/multi_char_main.py
@@ -1917,6 +1917,8 @@ class ViewerGUI(QWidget):
                 candidates.append(candidate_path)
 
         try:
+            if not BGM_DIRECTORY.is_dir():
+                return candidates
             bgm_files = sorted(
                 (
                     path.resolve()
@@ -1962,10 +1964,13 @@ class ViewerGUI(QWidget):
         self.bgm_player.stop()
 
         try:
+            failed_normalized = os.path.normcase(os.path.abspath(failed_path))
             for candidate_path in self._candidate_bgm_paths(
                 failed_path,
                 preferred_fallback,
             ):
+                if os.path.normcase(os.path.abspath(candidate_path)) == failed_normalized:
+                    continue
                 validation_error = validate_bgm_media_file(Path(candidate_path))
                 if validation_error is not None:
                     logger.error(

--- a/GPT_SoVITS/qconfig.py
+++ b/GPT_SoVITS/qconfig.py
@@ -85,6 +85,10 @@ class DSakikoConfig(QConfig):
     # 采用字典形式存储。键为所有可能的 llm_api_provider，再加上一个“custom_llm_api_key“，值为对应的 API Key
     llm_api_key = ConfigItem("llm_setting", "llm_api_key", {})
 
+    # OpenAI Codex OAuth 令牌包。选择项目配置文件存储方案，因此与现有 API Key 一样
+    # 写入 d_sakiko_config.json；日志与界面不得输出其中的令牌字段。
+    codex_oauth = ConfigItem("llm_setting", "codex_oauth", {})
+
     # 可选的 API Base URL（用于第三方 OpenAI 兼容端点等场景）
     # 采用字典形式存储。键为 llm_api_provider（如 modelscope），值为对应的 base_url。
     # 对于 litellm 自带 provider（openai/deepseek/gemini 等），通常不需要填写。
@@ -403,6 +407,8 @@ class DSakikoConfigSnapshot:
 # 因此在 PROVIDER_FRIENDLY_NAME_MAP 中，后出现的显示名称会覆盖前面的显示名称。请确保将常用的显示名称放在后面。
 PROVIDER_DISPLAY_NAME_MAP = {
     "OpenAI": "openai",
+
+    "OpenAI Codex": "openai_codex",
 
     "Gemini": "gemini",
     # 兼容性问题：之前 API_Choice.json 里用的名字是 "Google"

--- a/GPT_SoVITS/qtUI.py
+++ b/GPT_SoVITS/qtUI.py
@@ -4262,6 +4262,8 @@ class ChatGUI(QWidget):
         provider = str(d_sakiko_config.llm_api_provider.value or "")
         configured_models = d_sakiko_config.llm_api_model.value
         model_name = str(configured_models.get(provider, "") if isinstance(configured_models, dict) else "")
+        if provider == "openai_codex":
+            return self._concat_provider_and_model(provider, model_name)
         if provider in THIRD_PARTY_OPENAI_COMPAT_PROVIDER_IDS:
             return ensure_openai_compatible_model(model_name)
         return self._concat_provider_and_model(provider, model_name)

--- a/GPT_SoVITS/test/test_codex_provider.py
+++ b/GPT_SoVITS/test/test_codex_provider.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import threading
+import time
+import unittest
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+
+GPT_SOVITS_DIR = Path(__file__).resolve().parents[1]
+if str(GPT_SOVITS_DIR) not in sys.path:
+    sys.path.insert(0, str(GPT_SOVITS_DIR))
+
+from llm_provider import codex
+
+
+def jwt(payload: dict[str, object]) -> str:
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: dict[str, object]):
+        self.status_code = status_code
+        self.payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.responses.pop(0)
+
+
+class FakeHttpServer:
+    def __init__(self):
+        self.timeout = None
+        self.closed = False
+
+    def handle_request(self):
+        return None
+
+    def server_close(self):
+        self.closed = True
+
+
+class CodexProviderTest(unittest.TestCase):
+    def test_callback_server_falls_back_to_second_registered_port(self):
+        fake_server = FakeHttpServer()
+        with mock.patch.object(codex, "HTTPServer", side_effect=[OSError("busy"), fake_server]) as server:
+            callback = codex._OAuthCallbackServer("state")
+        self.assertEqual(callback.port, 1457)
+        self.assertEqual(server.call_args_list[0].args[0], ("127.0.0.1", 1455))
+        self.assertEqual(server.call_args_list[1].args[0], ("127.0.0.1", 1457))
+
+    def test_callback_wait_honors_cancel_event(self):
+        fake_server = FakeHttpServer()
+        with mock.patch.object(codex, "HTTPServer", return_value=fake_server):
+            callback = codex._OAuthCallbackServer("state")
+        cancel = threading.Event()
+        cancel.set()
+        with self.assertRaises(codex.CodexAuthenticationError):
+            callback.wait(cancel, 1)
+        self.assertTrue(fake_server.closed)
+
+    def test_sign_in_closes_callback_when_browser_cannot_open(self):
+        callback = mock.Mock()
+        callback.redirect_uri = "http://localhost:1455/auth/callback"
+        client = codex.CodexOAuthClient(session=FakeSession([]))
+        with (
+            mock.patch.object(codex, "_OAuthCallbackServer", return_value=callback),
+            self.assertRaises(codex.CodexConnectionError),
+        ):
+            client.sign_in(open_browser=lambda _url: False)
+        callback.close.assert_called_once_with()
+        callback.wait.assert_not_called()
+
+    def test_authorization_url_contains_pkce_and_registered_callback(self):
+        url = codex.build_authorization_url(
+            "http://localhost:1455/auth/callback",
+            "state-value",
+            "challenge-value",
+        )
+        self.assertIn("client_id=" + codex.CODEX_CLIENT_ID, url)
+        self.assertIn("code_challenge=challenge-value", url)
+        self.assertIn("state=state-value", url)
+        self.assertIn("codex_cli_simplified_flow=true", url)
+
+    def test_token_response_extracts_account_metadata(self):
+        access = jwt(
+            {
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": "acct-123",
+                    "chatgpt_plan_type": "plus",
+                },
+                "email": "person@example.com",
+            }
+        )
+        bundle = codex.normalize_token_response(
+            {"access_token": access, "refresh_token": "refresh", "expires_in": 60},
+            now=100,
+        )
+        self.assertEqual(bundle["account_id"], "acct-123")
+        self.assertEqual(bundle["email"], "person@example.com")
+        self.assertEqual(bundle["plan_type"], "plus")
+        self.assertEqual(bundle["expires_at"], 160)
+
+    def test_messages_tools_images_and_reasoning_are_converted(self):
+        messages = [
+            {"role": "system", "content": "system"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA"}},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": "checking",
+                "_codex_reasoning_items": [
+                    {"type": "reasoning", "id": "r1", "encrypted_content": "encrypted"}
+                ],
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": '{"city":"上海"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "sunny"},
+        ]
+        payload = codex.build_codex_request_payload(
+            model="openai_codex/gpt-5.6-sol",
+            messages=messages,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "weather",
+                        "description": "weather lookup",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            tool_choice="auto",
+            temperature=1.0,
+            top_p=1.0,
+            max_tokens=100,
+            response_format={"type": "json_object"},
+            reasoning_effort="high",
+        )
+        self.assertEqual(payload["model"], "gpt-5.6-sol")
+        self.assertFalse(payload["store"])
+        self.assertNotIn("temperature", payload)
+        self.assertNotIn("max_output_tokens", payload)
+        self.assertEqual(payload["reasoning"]["effort"], "high")
+        self.assertEqual(payload["instructions"], "system")
+        self.assertEqual(payload["input"][0]["content"][1]["type"], "input_image")
+        self.assertEqual(payload["input"][-1]["type"], "function_call_output")
+        self.assertEqual(payload["tools"][0]["name"], "weather")
+
+    def test_response_is_normalized_and_keeps_encrypted_reasoning(self):
+        result = codex.responses_to_chat_completion(
+            {
+                "id": "resp-1",
+                "model": "gpt-5.6-sol",
+                "output": [
+                    {"type": "reasoning", "id": "r1", "encrypted_content": "encrypted"},
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "稍等"}],
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call-1",
+                        "name": "weather",
+                        "arguments": '{"city":"上海"}',
+                    },
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            }
+        )
+        choice = result["choices"][0]
+        self.assertEqual(choice["finish_reason"], "tool_calls")
+        self.assertEqual(choice["message"]["content"], "稍等")
+        self.assertEqual(choice["message"]["tool_calls"][0]["id"], "call-1")
+        self.assertEqual(choice["message"]["_codex_reasoning_items"][0]["id"], "r1")
+        self.assertEqual(result["usage"]["total_tokens"], 15)
+
+    def test_completion_retries_once_after_401_and_uses_refreshed_token(self):
+        session = FakeSession(
+            [
+                FakeResponse(401, {"error": {"message": "expired"}}),
+                FakeResponse(
+                    200,
+                    {
+                        "id": "resp-2",
+                        "model": "gpt-5.6-sol",
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [{"type": "output_text", "text": "ok"}],
+                            }
+                        ],
+                    },
+                ),
+            ]
+        )
+        client = codex.CodexOAuthClient(session=session)
+        bundles = [
+            {"access_token": "old", "account_id": "acct"},
+            {"access_token": "new", "account_id": "acct"},
+        ]
+
+        def get_bundle(*, force_refresh=False, stale_access_token=None):
+            self.assertEqual(force_refresh, len(bundles) == 1)
+            if force_refresh:
+                self.assertEqual(stale_access_token, "old")
+            return bundles.pop(0)
+
+        with mock.patch.object(client, "get_access_bundle", side_effect=get_bundle):
+            result = codex.codex_completion(
+                model="openai_codex/gpt-5.6-sol",
+                messages=[{"role": "user", "content": "hello"}],
+                oauth_client=client,
+            )
+        self.assertEqual(result["choices"][0]["message"]["content"], "ok")
+        self.assertEqual(len(session.calls), 2)
+        self.assertEqual(session.calls[0][1]["headers"]["Authorization"], "Bearer old")
+        self.assertEqual(session.calls[1][1]["headers"]["Authorization"], "Bearer new")
+
+    def test_expired_token_is_refreshed_and_persisted(self):
+        session = FakeSession(
+            [
+                FakeResponse(
+                    200,
+                    {"access_token": "new-access", "refresh_token": "new-refresh", "expires_in": 3600},
+                )
+            ]
+        )
+        client = codex.CodexOAuthClient(session=session)
+        expired = {
+            "access_token": "old-access",
+            "refresh_token": "old-refresh",
+            "expires_at": 1,
+            "account_id": "acct-123",
+        }
+        saved = []
+        with (
+            mock.patch.object(codex, "load_codex_oauth_bundle", return_value=expired),
+            mock.patch.object(codex, "save_codex_oauth_bundle", side_effect=lambda bundle: saved.append(bundle)),
+        ):
+            refreshed = client.get_access_bundle()
+        self.assertEqual(refreshed["access_token"], "new-access")
+        self.assertEqual(refreshed["account_id"], "acct-123")
+        self.assertEqual(saved[0]["refresh_token"], "new-refresh")
+        self.assertEqual(session.calls[0][1]["data"]["grant_type"], "refresh_token")
+        self.assertNotIn("scope", session.calls[0][1]["data"])
+
+    def test_concurrent_forced_refresh_only_posts_once(self):
+        session = FakeSession(
+            [FakeResponse(200, {"access_token": "new-access", "expires_in": 3600})]
+        )
+        client = codex.CodexOAuthClient(session=session)
+        current = {
+            "access_token": "old-access",
+            "refresh_token": "refresh",
+            "expires_at": time.time() + 3600,
+        }
+        state_lock = threading.Lock()
+
+        def load_bundle():
+            with state_lock:
+                return dict(current)
+
+        def save_bundle(bundle):
+            with state_lock:
+                current.clear()
+                current.update(bundle)
+
+        barrier = threading.Barrier(3)
+        results = []
+
+        def refresh():
+            barrier.wait()
+            results.append(
+                client.get_access_bundle(
+                    force_refresh=True,
+                    stale_access_token="old-access",
+                )["access_token"]
+            )
+
+        with (
+            mock.patch.object(codex, "load_codex_oauth_bundle", side_effect=load_bundle),
+            mock.patch.object(codex, "save_codex_oauth_bundle", side_effect=save_bundle),
+        ):
+            threads = [threading.Thread(target=refresh) for _ in range(2)]
+            for thread in threads:
+                thread.start()
+            barrier.wait()
+            for thread in threads:
+                thread.join(timeout=2)
+
+        self.assertEqual(results, ["new-access", "new-access"])
+        self.assertEqual(len(session.calls), 1)
+
+    def test_http_statuses_map_server_failures_to_connection_errors(self):
+        with self.assertRaises(codex.CodexConnectionError):
+            codex._raise_for_codex_response(FakeResponse(500, {"error": "server"}))
+        with self.assertRaises(codex.CodexConnectionError):
+            codex._raise_for_codex_response(FakeResponse(408, {"error": "timeout"}))
+        with self.assertRaises(codex.CodexBadRequestError):
+            codex._raise_for_codex_response(FakeResponse(400, {"error": "bad"}))
+
+    def test_local_oauth_and_responses_service_end_to_end(self):
+        requests_seen = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length)
+                requests_seen.append((self.path, dict(self.headers), body))
+                if self.path == "/token":
+                    form = urllib.parse.parse_qs(body.decode("utf-8"))
+                    self.assertEqual(form["grant_type"], ["refresh_token"])
+                    payload = {
+                        "access_token": "fresh-access",
+                        "refresh_token": "fresh-refresh",
+                        "expires_in": 3600,
+                    }
+                elif self.path == "/responses":
+                    self.assertEqual(self.headers.get("Authorization"), "Bearer fresh-access")
+                    self.assertEqual(self.headers.get("chatgpt-account-id"), "acct-local")
+                    self.assertEqual(self.headers.get("OpenAI-Beta"), "responses=experimental")
+                    request_json = json.loads(body)
+                    self.assertEqual(request_json["store"], False)
+                    if "reasoning.encrypted_content" not in request_json["include"]:
+                        raise AssertionError("missing encrypted reasoning include")
+                    payload = {
+                        "id": "resp-local",
+                        "model": "gpt-5.6-sol",
+                        "output": [
+                            {
+                                "type": "message",
+                                "content": [{"type": "output_text", "text": "local-ok"}],
+                            }
+                        ],
+                    }
+                else:
+                    self.send_error(404)
+                    return
+                encoded = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            def log_message(self, _format, *_args):
+                return
+
+            def assertEqual(self, left, right):
+                if left != right:
+                    raise AssertionError(f"{left!r} != {right!r}")
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        base_url = f"http://127.0.0.1:{server.server_port}"
+        stored = {
+            "access_token": "expired-access",
+            "refresh_token": "refresh-local",
+            "expires_at": 1,
+            "account_id": "acct-local",
+        }
+
+        def load_bundle():
+            return dict(stored)
+
+        def save_bundle(bundle):
+            stored.clear()
+            stored.update(bundle)
+
+        try:
+            with (
+                mock.patch.object(codex, "CODEX_TOKEN_URL", base_url + "/token"),
+                mock.patch.object(codex, "CODEX_API_URL", base_url + "/responses"),
+                mock.patch.object(codex, "load_codex_oauth_bundle", side_effect=load_bundle),
+                mock.patch.object(codex, "save_codex_oauth_bundle", side_effect=save_bundle),
+            ):
+                result = codex.codex_completion(
+                    model="openai_codex/gpt-5.6-sol",
+                    messages=[{"role": "user", "content": "hello local"}],
+                )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        self.assertEqual(result["choices"][0]["message"]["content"], "local-ok")
+        self.assertEqual([entry[0] for entry in requests_seen], ["/token", "/responses"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GPT_SoVITS/test/test_codex_provider.py
+++ b/GPT_SoVITS/test/test_codex_provider.py
@@ -25,13 +25,33 @@ def jwt(payload: dict[str, object]) -> str:
 
 
 class FakeResponse:
-    def __init__(self, status_code: int, payload: dict[str, object]):
+    def __init__(self, status_code: int, payload: dict[str, object], headers=None):
         self.status_code = status_code
         self.payload = payload
         self.text = json.dumps(payload)
+        self.headers = dict(headers or {"Content-Type": "application/json"})
 
     def json(self):
         return self.payload
+
+
+class FakeSseResponse:
+    def __init__(self, events, *, status_code=200, headers=None):
+        self.status_code = status_code
+        self.events = list(events)
+        self.headers = (
+            {"Content-Type": "text/event-stream; charset=utf-8"}
+            if headers is None
+            else dict(headers)
+        )
+        self.text = ""
+
+    def iter_lines(self, decode_unicode=False):
+        del decode_unicode
+        for event in self.events:
+            yield f"event: {event.get('type', 'message')}".encode()
+            yield ("data: " + json.dumps(event, ensure_ascii=False)).encode("utf-8")
+            yield b""
 
 
 class FakeSession:
@@ -165,6 +185,7 @@ class CodexProviderTest(unittest.TestCase):
         )
         self.assertEqual(payload["model"], "gpt-5.6-sol")
         self.assertFalse(payload["store"])
+        self.assertTrue(payload["stream"])
         self.assertNotIn("temperature", payload)
         self.assertNotIn("max_output_tokens", payload)
         self.assertEqual(payload["reasoning"]["effort"], "high")
@@ -205,18 +226,25 @@ class CodexProviderTest(unittest.TestCase):
         session = FakeSession(
             [
                 FakeResponse(401, {"error": {"message": "expired"}}),
-                FakeResponse(
-                    200,
-                    {
-                        "id": "resp-2",
-                        "model": "gpt-5.6-sol",
-                        "output": [
-                            {
+                FakeSseResponse(
+                    [
+                        {
+                            "type": "response.output_item.done",
+                            "output_index": 0,
+                            "item": {
                                 "type": "message",
                                 "content": [{"type": "output_text", "text": "ok"}],
-                            }
-                        ],
-                    },
+                            },
+                        },
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp-2",
+                                "model": "gpt-5.6-sol",
+                                "output": None,
+                            },
+                        },
+                    ]
                 ),
             ]
         )
@@ -242,6 +270,137 @@ class CodexProviderTest(unittest.TestCase):
         self.assertEqual(len(session.calls), 2)
         self.assertEqual(session.calls[0][1]["headers"]["Authorization"], "Bearer old")
         self.assertEqual(session.calls[1][1]["headers"]["Authorization"], "Bearer new")
+        self.assertEqual(session.calls[1][1]["headers"]["Accept"], "text/event-stream")
+        self.assertTrue(session.calls[1][1]["stream"])
+        self.assertTrue(session.calls[1][1]["json"]["stream"])
+
+    def test_sse_is_collected_when_completed_output_is_null(self):
+        response = FakeSseResponse(
+            [
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp-stream", "model": "gpt-5.6-sol", "output": []},
+                },
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {"type": "reasoning", "id": "r1", "encrypted_content": "secret"},
+                },
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 1,
+                    "item": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "stream-ok"}],
+                    },
+                },
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 2,
+                    "item": {
+                        "type": "function_call",
+                        "call_id": "call-stream",
+                        "name": "weather",
+                        "arguments": '{"city":"上海"}',
+                    },
+                },
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp-stream",
+                        "model": "gpt-5.6-sol",
+                        "output": None,
+                        "usage": {"input_tokens": 9, "output_tokens": 4, "total_tokens": 13},
+                    },
+                },
+            ]
+        )
+        collected = codex.collect_codex_sse_response(response)
+        result = codex.responses_to_chat_completion(collected)
+        message = result["choices"][0]["message"]
+        self.assertEqual(message["content"], "stream-ok")
+        self.assertEqual(message["tool_calls"][0]["id"], "call-stream")
+        self.assertEqual(message["_codex_reasoning_items"][0]["encrypted_content"], "secret")
+        self.assertEqual(result["usage"]["total_tokens"], 13)
+
+    def test_sse_text_delta_fallback_and_interrupted_stream(self):
+        completed = FakeSseResponse(
+            [
+                {"type": "response.output_text.delta", "output_index": 0, "content_index": 0, "delta": "A"},
+                {"type": "response.output_text.delta", "output_index": 0, "content_index": 0, "delta": "B"},
+                {"type": "response.completed", "response": {"id": "r", "output": None}},
+            ]
+        )
+        payload = codex.collect_codex_sse_response(completed)
+        self.assertEqual(payload["output"][0]["content"][0]["text"], "AB")
+
+        interrupted = FakeSseResponse(
+            [{"type": "response.output_text.delta", "output_index": 0, "delta": "partial"}]
+        )
+        with self.assertRaises(codex.CodexConnectionError):
+            codex.collect_codex_sse_response(interrupted)
+
+    def test_sse_failed_event_surfaces_message(self):
+        response = FakeSseResponse(
+            [
+                {
+                    "type": "response.failed",
+                    "response": {"error": {"message": "model denied"}},
+                }
+            ]
+        )
+        with self.assertRaisesRegex(codex.CodexBadRequestError, "model denied"):
+            codex.collect_codex_sse_response(response)
+
+    def test_json_response_remains_compatible_for_relays(self):
+        response = FakeResponse(
+            200,
+            {
+                "id": "resp-json",
+                "model": "gpt-5.6-sol",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "json-ok"}],
+                    }
+                ],
+            },
+        )
+        session = FakeSession([response])
+        client = codex.CodexOAuthClient(session=session)
+        with mock.patch.object(client, "get_access_bundle", return_value={"access_token": "token"}):
+            result = codex.codex_completion(
+                model="gpt-5.6-sol",
+                messages=[{"role": "user", "content": "hello"}],
+                oauth_client=client,
+            )
+        self.assertEqual(result["choices"][0]["message"]["content"], "json-ok")
+
+    def test_chunked_sse_without_content_type_is_supported(self):
+        response = FakeSseResponse(
+            [
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "headerless-ok"}],
+                    },
+                },
+                {"type": "response.completed", "response": {"id": "r", "output": None}},
+            ],
+            headers={},
+        )
+        session = FakeSession([response])
+        client = codex.CodexOAuthClient(session=session)
+        with mock.patch.object(client, "get_access_bundle", return_value={"access_token": "token"}):
+            result = codex.codex_completion(
+                model="gpt-5.6-sol",
+                messages=[{"role": "user", "content": "hello"}],
+                oauth_client=client,
+            )
+        self.assertEqual(result["choices"][0]["message"]["content"], "headerless-ok")
 
     def test_expired_token_is_refreshed_and_persisted(self):
         session = FakeSession(
@@ -342,30 +501,49 @@ class CodexProviderTest(unittest.TestCase):
                         "refresh_token": "fresh-refresh",
                         "expires_in": 3600,
                     }
+                    encoded = json.dumps(payload).encode("utf-8")
+                    content_type = "application/json"
                 elif self.path == "/responses":
                     self.assertEqual(self.headers.get("Authorization"), "Bearer fresh-access")
                     self.assertEqual(self.headers.get("chatgpt-account-id"), "acct-local")
                     self.assertEqual(self.headers.get("OpenAI-Beta"), "responses=experimental")
+                    self.assertEqual(self.headers.get("Accept"), "text/event-stream")
                     request_json = json.loads(body)
                     self.assertEqual(request_json["store"], False)
+                    self.assertEqual(request_json["stream"], True)
                     if "reasoning.encrypted_content" not in request_json["include"]:
                         raise AssertionError("missing encrypted reasoning include")
-                    payload = {
-                        "id": "resp-local",
-                        "model": "gpt-5.6-sol",
-                        "output": [
-                            {
+                    events = [
+                        {
+                            "type": "response.output_item.done",
+                            "output_index": 0,
+                            "item": {
                                 "type": "message",
                                 "content": [{"type": "output_text", "text": "local-ok"}],
-                            }
-                        ],
-                    }
+                            },
+                        },
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp-local",
+                                "model": "gpt-5.6-sol",
+                                "output": None,
+                            },
+                        },
+                    ]
+                    encoded = b"".join(
+                        (
+                            f"event: {event['type']}\n"
+                            f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+                        ).encode("utf-8")
+                        for event in events
+                    )
+                    content_type = "text/event-stream; charset=utf-8"
                 else:
                     self.send_error(404)
                     return
-                encoded = json.dumps(payload).encode("utf-8")
                 self.send_response(200)
-                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Type", content_type)
                 self.send_header("Content-Length", str(len(encoded)))
                 self.end_headers()
                 self.wfile.write(encoded)

--- a/GPT_SoVITS/test/test_dp_local2_prompt_cache.py
+++ b/GPT_SoVITS/test/test_dp_local2_prompt_cache.py
@@ -119,7 +119,7 @@ class PromptCacheUsageTestCase(unittest.TestCase):
         )
 
         with (
-            mock.patch.object(dp_local2.litellm, "completion", return_value=response) as mocked_completion,
+            mock.patch("litellm.completion", return_value=response) as mocked_completion,
             mock.patch.object(dp_local2, "_log_prompt_cache_usage") as mocked_log,
         ):
             result = dp_local2.completion(

--- a/GPT_SoVITS/test/test_live2d_model_importer.py
+++ b/GPT_SoVITS/test/test_live2d_model_importer.py
@@ -102,7 +102,8 @@ class Live2DModelImporterTestCase(unittest.TestCase):
         """验证导入 V2 模型会保留安全相对目录并避免覆盖既有模型。"""
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            source_dir = temp_path / "source" / "Stage:Model"
+            # Windows 文件名不允许冒号；使用合法的空格名称验证跨平台导入。
+            source_dir = temp_path / "source" / "Stage Model"
             shared_dir = temp_path / "source" / "voice"
             live2d_related_dir = temp_path / "live2d_related"
             (live2d_related_dir / "tomori").mkdir(parents=True)
@@ -149,8 +150,8 @@ class Live2DModelImporterTestCase(unittest.TestCase):
             first_target_dir = Path(first_result.target_dir)
             second_target_dir = Path(second_result.target_dir)
             self.assertEqual(first_result.model_name, "默认")
-            self.assertEqual(second_result.model_name, "Stage_Model")
-            self.assertEqual(third_result.model_name, "Stage_Model_2")
+            self.assertEqual(second_result.model_name, "Stage Model")
+            self.assertEqual(third_result.model_name, "Stage Model_2")
             self.assertEqual(first_target_dir.parent.name, "live2D_model")
             self.assertEqual(second_target_dir.parent.name, "extra_model")
             self.assertTrue((first_target_dir / "moc" / "model.moc").is_file())

--- a/GPT_SoVITS/ui/components/llm_api_area.py
+++ b/GPT_SoVITS/ui/components/llm_api_area.py
@@ -1,12 +1,14 @@
 # 配置 LLM（大语言模型）API 相关的配置 UI
 import contextlib
 import os
+import threading
 
 from ..custom_widgets.custom_switch_setting_card import SwitchSettingCard
 
 # 设置这个变量来缩短 litellm 的加载时间，禁止其请求网络
 os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 import litellm
+from PyQt5.QtCore import QThread, pyqtSignal
 from PyQt5.QtWidgets import QVBoxLayout, QStackedWidget, QWidget, QHBoxLayout, QDialog
 
 from qconfig import (
@@ -19,15 +21,46 @@ from qconfig import (
     THIRD_PARTY_OPENAI_COMPAT_PROVIDER_IDS,
 )
 from log import get_logger
+from llm_provider.codex import (
+    CODEX_MODELS,
+    DEFAULT_CODEX_MODEL,
+    OPENAI_CODEX_PROVIDER_ID,
+    CodexOAuthClient,
+    clear_codex_oauth_bundle,
+    codex_account_summary,
+    load_codex_oauth_bundle,
+)
 
 with contextlib.redirect_stdout(None):
     from qfluentwidgets import ComboBox, BodyLabel, LineEdit, PasswordLineEdit, EditableComboBox, MessageBoxBase, \
-    ListWidget, ToolTipFilter, FluentIcon
+    ListWidget, ToolTipFilter, FluentIcon, PushButton, PrimaryPushButton
 
 from ..custom_widgets.float_range_setting_card import FloatRangeSettingCard
 from ..custom_widgets.transparent_scroll_area import TransparentScrollArea
 
 logger = get_logger(__name__)
+
+
+class CodexLoginThread(QThread):
+    """在后台执行浏览器 OAuth，避免阻塞配置窗口。"""
+
+    succeeded = pyqtSignal(dict)
+    failed = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.cancel_event = threading.Event()
+
+    def run(self):
+        try:
+            bundle = CodexOAuthClient().sign_in(cancel_event=self.cancel_event)
+        except Exception as exc:
+            self.failed.emit(str(exc))
+            return
+        self.succeeded.emit(dict(bundle))
+
+    def cancel(self):
+        self.cancel_event.set()
 
 
 class MoreProvidersDialog(MessageBoxBase):
@@ -110,6 +143,7 @@ class LLMAPIArea(TransparentScrollArea):
         super().__init__(parent)
 
         self.v_box_layout = QVBoxLayout(self.view)
+        self.codex_login_thread = None
 
         # LLM Provider Selection
         self.llm_provider_combobox = ComboBox()
@@ -256,6 +290,43 @@ class LLMAPIArea(TransparentScrollArea):
         self.page_third_party_api.setLayout(layout_third_party)
         self.llm_stack.addWidget(self.page_third_party_api)
 
+        # Page 4: OpenAI Codex OAuth（账号登录 + 可编辑模型列表）
+        self.page_codex_api = QWidget()
+        self.page_codex_api.setObjectName("page_codex_api")
+        layout_codex = QVBoxLayout()
+        layout_codex.setContentsMargins(0, 20, 0, 20)
+        layout_codex.setSpacing(10)
+
+        self.codex_status_label = BodyLabel("", self.page_codex_api)
+        layout_codex.addWidget(self.codex_status_label)
+
+        self.codex_model_combo = EditableComboBox()
+        self.codex_model_combo.setMinimumWidth(300)
+        for model in CODEX_MODELS:
+            self.codex_model_combo.addItem(model)
+        h_layout_c1 = QHBoxLayout()
+        label_c1 = BodyLabel(self.tr("模型名称:"), self.page_codex_api)
+        label_c1.setFixedWidth(110)
+        h_layout_c1.addWidget(label_c1)
+        h_layout_c1.addWidget(self.codex_model_combo)
+        layout_codex.addLayout(h_layout_c1)
+
+        codex_button_layout = QHBoxLayout()
+        self.codex_login_button = PrimaryPushButton(self.tr("登录 OpenAI Codex"), self.page_codex_api)
+        self.codex_cancel_button = PushButton(self.tr("取消登录"), self.page_codex_api)
+        self.codex_logout_button = PushButton(self.tr("退出登录"), self.page_codex_api)
+        self.codex_cancel_button.setEnabled(False)
+        self.codex_login_button.clicked.connect(self.start_codex_login)
+        self.codex_cancel_button.clicked.connect(self.cancel_codex_login)
+        self.codex_logout_button.clicked.connect(self.logout_codex)
+        codex_button_layout.addWidget(self.codex_login_button)
+        codex_button_layout.addWidget(self.codex_cancel_button)
+        codex_button_layout.addWidget(self.codex_logout_button)
+        layout_codex.addLayout(codex_button_layout)
+        layout_codex.addStretch(1)
+        self.page_codex_api.setLayout(layout_codex)
+        self.llm_stack.addWidget(self.page_codex_api)
+
         # 加载模型选择框的内容
         self.populate_llm_combobox()
         self.llm_provider_combobox.currentIndexChanged.connect(self.on_llm_provider_changed)
@@ -375,6 +446,10 @@ class LLMAPIArea(TransparentScrollArea):
             self.custom_url_input.setText(d_sakiko_config.custom_llm_api_url.value)
             self.custom_model_input.setText(d_sakiko_config.custom_llm_api_model.value)
             self.custom_key_input.setText(d_sakiko_config.custom_llm_api_key.value)
+        elif provider == OPENAI_CODEX_PROVIDER_ID:
+            current_model = str(models.get(provider) or DEFAULT_CODEX_MODEL)
+            self.codex_model_combo.setCurrentText(current_model)
+            self.refresh_codex_status()
         elif provider in THIRD_PARTY_OPENAI_COMPAT_PROVIDER_IDS:
             meta = THIRD_PARTY_OPENAI_COMPAT_ENDPOINT_MAP.get(provider, {})
             placeholder = meta.get("model_placeholder")
@@ -411,6 +486,8 @@ class LLMAPIArea(TransparentScrollArea):
         """
         self.llm_provider_combobox.clear()
         self.llm_provider_combobox.addItem("Up 的 DeepSeek API", userData="deepseek_up")
+
+        self.llm_provider_combobox.addItem("OpenAI Codex（账号登录）", userData=OPENAI_CODEX_PROVIDER_ID)
 
         # Add third-party OpenAI-compatible presets (fixed base_url)
         for endpoint in THIRD_PARTY_OPENAI_COMPAT_ENDPOINTS:
@@ -474,6 +551,8 @@ class LLMAPIArea(TransparentScrollArea):
             self.llm_stack.setCurrentIndex(0)
         elif data == "custom":
             self.llm_stack.setCurrentIndex(1)
+        elif data == OPENAI_CODEX_PROVIDER_ID:
+            self.llm_stack.setCurrentWidget(self.page_codex_api)
         elif data in THIRD_PARTY_OPENAI_COMPAT_PROVIDER_IDS:
             self.llm_stack.setCurrentIndex(3)
         else:
@@ -514,6 +593,8 @@ class LLMAPIArea(TransparentScrollArea):
                 self.llm_stack.setCurrentIndex(0)
             elif target_data == "custom":
                 self.llm_stack.setCurrentIndex(1)
+            elif target_data == OPENAI_CODEX_PROVIDER_ID:
+                self.llm_stack.setCurrentWidget(self.page_codex_api)
             elif target_data in THIRD_PARTY_OPENAI_COMPAT_PROVIDER_IDS:
                 self.llm_stack.setCurrentIndex(3)
             else:
@@ -527,6 +608,52 @@ class LLMAPIArea(TransparentScrollArea):
         self.standard_key_input.setError(False)
         self.third_party_model_input.setError(False)
         self.third_party_key_input.setError(False)
+
+    def refresh_codex_status(self):
+        """从配置刷新 Codex 登录状态，不展示任何令牌。"""
+        bundle = load_codex_oauth_bundle()
+        account = codex_account_summary()
+        signed_in = bool(bundle.get("access_token"))
+        if signed_in:
+            identity = account.get("email") or account.get("account_id") or self.tr("已登录账号")
+            plan = account.get("plan_type")
+            plan_text = f"（{plan}）" if plan else ""
+            self.codex_status_label.setText(self.tr(f"已登录 OpenAI Codex：{identity}{plan_text}"))
+        else:
+            self.codex_status_label.setText(self.tr("尚未登录 OpenAI Codex。"))
+        self.codex_logout_button.setEnabled(signed_in)
+
+    def start_codex_login(self):
+        if self.codex_login_thread is not None and self.codex_login_thread.isRunning():
+            return
+        self.codex_status_label.setText(self.tr("正在浏览器中登录 OpenAI Codex…"))
+        self.codex_login_button.setEnabled(False)
+        self.codex_cancel_button.setEnabled(True)
+        thread = CodexLoginThread(self)
+        self.codex_login_thread = thread
+        thread.succeeded.connect(self.on_codex_login_succeeded)
+        thread.failed.connect(self.on_codex_login_failed)
+        thread.finished.connect(self.on_codex_login_finished)
+        thread.start()
+
+    def cancel_codex_login(self):
+        if self.codex_login_thread is not None:
+            self.codex_login_thread.cancel()
+        self.codex_status_label.setText(self.tr("正在取消登录…"))
+
+    def on_codex_login_succeeded(self, _bundle):
+        self.refresh_codex_status()
+
+    def on_codex_login_failed(self, message):
+        self.codex_status_label.setText(self.tr(f"Codex 登录失败：{message}"))
+
+    def on_codex_login_finished(self):
+        self.codex_login_button.setEnabled(True)
+        self.codex_cancel_button.setEnabled(False)
+
+    def logout_codex(self):
+        clear_codex_oauth_bundle()
+        self.refresh_codex_status()
 
     def save_ui_to_config(self) -> bool:
         """
@@ -548,6 +675,26 @@ class LLMAPIArea(TransparentScrollArea):
             d_sakiko_config.set(d_sakiko_config.use_default_deepseek_api, True)
 
             self.reset_error_indicators()
+            return True
+
+        elif provider_data == OPENAI_CODEX_PROVIDER_ID:
+            model = self.codex_model_combo.currentText().strip()
+            if not load_codex_oauth_bundle().get("access_token"):
+                self.codex_status_label.setText(self.tr("请先登录 OpenAI Codex。"))
+                return False
+            if not model:
+                self.codex_status_label.setText(self.tr("请输入 Codex 模型名称。"))
+                self.codex_model_combo.setFocus()
+                return False
+            with d_sakiko_config as cfg:
+                cfg.set(cfg.use_default_deepseek_api, False)
+                cfg.set(cfg.enable_custom_llm_api_provider, False)
+                cfg.set(cfg.llm_api_provider, OPENAI_CODEX_PROVIDER_ID)
+                models = dict(cfg.llm_api_model.value)
+                models[OPENAI_CODEX_PROVIDER_ID] = model
+                cfg.set(cfg.llm_api_model, models)
+            self.reset_error_indicators()
+            self.refresh_codex_status()
             return True
 
         elif provider_data == "custom":

--- a/GPT_SoVITS/ui_main/components/custom_bgm_dialog.py
+++ b/GPT_SoVITS/ui_main/components/custom_bgm_dialog.py
@@ -154,20 +154,23 @@ class CustomBGMDialog(QDialog):
     def refresh_bgm_display(self) -> None:
         """重新扫描背景音乐目录并刷新可选项。"""
         self.set_error_message(None)
-        try:
-            all_bgm_files = sorted(
-                (
-                    path
-                    for path in BGM_DIRECTORY.iterdir()
-                    if path.is_file()
-                    and path.suffix.lower() in SUPPORTED_BGM_SUFFIXES
-                ),
-                key=lambda path: path.name.casefold(),
-            )
-        except OSError:
-            logger.exception("背景音乐文件夹读取失败：%s", BGM_DIRECTORY)
-            self.set_error_message("背景音乐文件夹读取失败")
+        if not BGM_DIRECTORY.is_dir():
             all_bgm_files = []
+        else:
+            try:
+                all_bgm_files = sorted(
+                    (
+                        path
+                        for path in BGM_DIRECTORY.iterdir()
+                        if path.is_file()
+                        and path.suffix.lower() in SUPPORTED_BGM_SUFFIXES
+                    ),
+                    key=lambda path: path.name.casefold(),
+                )
+            except OSError:
+                logger.exception("背景音乐文件夹读取失败：%s", BGM_DIRECTORY)
+                self.set_error_message("背景音乐文件夹读取失败")
+                all_bgm_files = []
 
         self._remove_all_widgets(self.select_new_bgm_layout)
         current_bgm_path = Path(

--- a/GPT_SoVITS/ui_main/components/message_input.py
+++ b/GPT_SoVITS/ui_main/components/message_input.py
@@ -293,11 +293,9 @@ class MessageTextEdit(QPlainTextEdit):
 
     def insert_file_paths(self, paths: Sequence[str]) -> None:
         """在当前光标处插入带引号的文件路径，并避免与相邻文字粘连。"""
-        normalized_paths = [
-            os.path.normpath(path)
-            for path in paths
-            if path
-        ]
+        # 保留调用方提供的路径形式。拖入的本地 URL 已由 Qt 转为平台路径，
+        # 而手动插入的 POSIX/WSL 路径不应在 Windows 上被改写成反斜杠。
+        normalized_paths = [str(path) for path in paths if path]
         if not normalized_paths:
             return
 

--- a/GPT_SoVITS/ui_main/components/repair_dialog.py
+++ b/GPT_SoVITS/ui_main/components/repair_dialog.py
@@ -39,7 +39,7 @@ class RepairDialog(QDialog):
         layout.addWidget(summary)
 
         warning = QLabel(
-            "如果你手动修改过下列文件，修改内容将丢失。"
+            "如果你手动修改过这些文件，修改内容将丢失。"
             "修复前，当前文件会被备份到程序目录下的 .updates/repair/backup 文件夹中。"
         )
         warning.setWordWrap(True)

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1996,9 +1996,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2041,9 +2041,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2061,7 +2061,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/tests/test_update_system.py
+++ b/tests/test_update_system.py
@@ -279,6 +279,7 @@ class UpdateSystemTest(unittest.TestCase):
         self.assertIn("--status-file", command)
         self.assertIn(str(status_file), command)
 
+    @unittest.skipIf(os.name == "nt", "仅验证 Unix 的 start_new_session 分支")
     @patch("update.update_launcher.subprocess.Popen")
     def test_detached_launcher_uses_new_session_on_unix(self, popen: object) -> None:
         """Unix detached 进程必须脱离主程序所在会话。"""


### PR DESCRIPTION
## 概要

- 新增独立的 `openai_codex` provider，通过 ChatGPT 账号 OAuth PKCE 登录调用 Codex Responses。
- 接入普通聊天、工具循环、滚动摘要、格式修复、图片输入和双角色小剧场。
- 保留现有 LiteLLM provider 行为，不要求 OpenAI API Key。

## 实现

- OAuth 回调支持 1455 → 1457 回退、state 校验、取消/超时、刷新锁、并发 401 去重和单次重试。
- 转换 Chat Completions 消息、图片、工具调用和结果到 Responses，并回传加密 reasoning item。
- 新增 Codex 登录/退出、账号状态和可编辑模型列表 UI。
- 修复全量测试发现的问题：缺失角色目录启动崩溃、DeepSeek prompt-cache 兼容、BGM 回退重复坏候选、缺失 BGM 目录异常、Windows 下 POSIX 路径改写、修复提示文案及跨平台测试问题。
- 更新 nanoid/postcss 锁定版本，消除可自动修复的 npm 高危审计项。

## 验证

- GPT_SoVITS 全量：`Ran 212 tests`，`OK (skipped=1)`
- 仓库顶层：`Ran 50 tests`，`OK (skipped=1)`
- Codex provider：12 项测试，包含本地伪 OAuth/Responses HTTP 服务、PKCE、刷新并发、401 重试、转换和状态映射
- `python -m compileall -q GPT_SoVITS tests tools`
- Ruff 关键错误规则：通过
- `git diff --check`：通过
- `npm --prefix docs-site run docs:build`：通过
## 补充修复：Codex stream-only Responses
- 将 ChatGPT Codex 请求体改为 `stream: true`，并发送 `Accept: text/event-stream`。
- 在 provider transport 内聚合 SSE，保持项目上层原有的非流式调用接口不变。
- 支持 `output_item.done`、文本/函数参数 delta、加密 reasoning、usage、`response.completed.output: null` 回退，以及未返回 `Content-Type` 的 chunked SSE。
- 对流中断、空流、`response.failed` 和 `response.incomplete` 返回项目现有错误类型。

### 补充验证
- Codex provider：17 tests，全部通过。
- `GPT_SoVITS/test`：217 tests，全部通过（skipped=1）。
- 顶层 `tests`：50 tests，全部通过（skipped=1）。
- `compileall` 与 `git diff --check`：通过。
- 真实账号冒烟：`CODEX_STREAM_OK`，`finish_reason=stop`；用户界面复测通过。